### PR TITLE
Make project board modal full-screen on mobile with bottom controls

### DIFF
--- a/src/__tests__/pages/games/scratchytd/roadmap.test.tsx
+++ b/src/__tests__/pages/games/scratchytd/roadmap.test.tsx
@@ -269,6 +269,44 @@ describe('ScratchyTD Roadmap Page', () => {
     })
   })
 
+  describe('Modal footer layout', () => {
+    beforeEach(() => mockFetchOk())
+
+    async function openModalFor(title: string) {
+      render(<ScratchyTDRoadmap {...defaultProps} />)
+      const titleEl = await screen.findByText(title)
+      fireEvent.click(titleEl.closest('.srm-card') as HTMLElement)
+      return await screen.findByRole('dialog')
+    }
+
+    it('places the close button inside the modal footer', async () => {
+      const dialog = await openModalFor('Laser Pointer Tower')
+      const footer = dialog.querySelector('.srm-modal-footer') as HTMLElement | null
+      expect(footer).not.toBeNull()
+      const closeBtn = within(dialog).getByRole('button', { name: /close/i })
+      expect(footer!.contains(closeBtn)).toBe(true)
+    })
+
+    it('places the View on GitHub link inside the modal footer', async () => {
+      const dialog = await openModalFor('Laser Pointer Tower')
+      const footer = dialog.querySelector('.srm-modal-footer') as HTMLElement | null
+      expect(footer).not.toBeNull()
+      const githubLink = within(dialog).getByRole('link', { name: /github/i })
+      expect(footer!.contains(githubLink)).toBe(true)
+    })
+
+    it('renders the footer after the body content in DOM order', async () => {
+      const dialog = await openModalFor('Markdown Demo')
+      const body = dialog.querySelector('.srm-modal-body') as HTMLElement
+      const footer = dialog.querySelector('.srm-modal-footer') as HTMLElement
+      expect(body).not.toBeNull()
+      expect(footer).not.toBeNull()
+      expect(
+        body.compareDocumentPosition(footer) & Node.DOCUMENT_POSITION_FOLLOWING
+      ).toBeTruthy()
+    })
+  })
+
   describe('Filters', () => {
     beforeEach(() => mockFetchOk())
 

--- a/src/pages/games/scratchytd/roadmap.tsx
+++ b/src/pages/games/scratchytd/roadmap.tsx
@@ -621,95 +621,98 @@ function BoardCardModal({ item, columns, onClose }: { item: BoardItem | null; co
         aria-labelledby="srm-modal-title"
         onClick={e => e.stopPropagation()}
       >
-        <button
-          ref={closeBtnRef}
-          type="button"
-          className="srm-modal-close"
-          aria-label="Close"
-          onClick={onClose}
-        >
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M6 6l12 12M6 18L18 6" />
-          </svg>
-        </button>
+        <div className="srm-modal-scroll">
+          <header className="srm-modal-header">
+            {item.status && (
+              <span className="srm-modal-status-pill" style={{ background: statusColor }}>
+                {item.status}
+              </span>
+            )}
+            <h2 id="srm-modal-title" className="srm-modal-title">{item.title}</h2>
+            {item.number != null && <span className="srm-modal-number">#{item.number}</span>}
+          </header>
 
-        <header className="srm-modal-header">
-          {item.status && (
-            <span className="srm-modal-status-pill" style={{ background: statusColor }}>
-              {item.status}
-            </span>
-          )}
-          <h2 id="srm-modal-title" className="srm-modal-title">{item.title}</h2>
-          {item.number != null && <span className="srm-modal-number">#{item.number}</span>}
-        </header>
-
-        {item.labels.length > 0 && (
-          <div className="srm-modal-tags">
-            {item.labels.map(l => {
-              const style = getLabelStyle(l.color);
-              return (
-                <span key={l.name} className="srm-card-tag" style={style}>
-                  {l.name}
-                </span>
-              );
-            })}
-          </div>
-        )}
-
-        {item.body ? (
-          <div
-            className="srm-modal-body srm-md"
-            dangerouslySetInnerHTML={{ __html: renderMarkdownBody(item.body) }}
-          />
-        ) : (
-          <div className="srm-modal-body">
-            <em className="srm-modal-empty">No description.</em>
-          </div>
-        )}
-
-        {item.assignees.length > 0 && (
-          <section className="srm-modal-assignees">
-            <div className="srm-modal-section-label">Assignees</div>
-            <div className="srm-modal-assignees-list">
-              {item.assignees.map(a => (
-                <a
-                  key={a.login}
-                  href={a.profileUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="srm-modal-assignee"
-                >
-                  <img src={a.avatarUrl} alt={a.login} className="srm-modal-avatar" width={28} height={28} />
-                  <span className="srm-modal-assignee-name">{a.login}</span>
-                </a>
-              ))}
+          {item.labels.length > 0 && (
+            <div className="srm-modal-tags">
+              {item.labels.map(l => {
+                const style = getLabelStyle(l.color);
+                return (
+                  <span key={l.name} className="srm-card-tag" style={style}>
+                    {l.name}
+                  </span>
+                );
+              })}
             </div>
-          </section>
-        )}
+          )}
 
-        {extraFields.length > 0 && (
-          <dl className="srm-modal-fields">
-            {extraFields.map(([k, v]) => (
-              v != null && (
-                <div key={k} className="srm-modal-field">
-                  <dt>{k}</dt>
-                  <dd>{String(v)}</dd>
-                </div>
-              )
-            ))}
-          </dl>
-        )}
+          {item.body ? (
+            <div
+              className="srm-modal-body srm-md"
+              dangerouslySetInnerHTML={{ __html: renderMarkdownBody(item.body) }}
+            />
+          ) : (
+            <div className="srm-modal-body">
+              <em className="srm-modal-empty">No description.</em>
+            </div>
+          )}
 
-        {item.url && (
-          <a
-            className="srm-modal-github"
-            href={item.url}
-            target="_blank"
-            rel="noopener noreferrer"
+          {item.assignees.length > 0 && (
+            <section className="srm-modal-assignees">
+              <div className="srm-modal-section-label">Assignees</div>
+              <div className="srm-modal-assignees-list">
+                {item.assignees.map(a => (
+                  <a
+                    key={a.login}
+                    href={a.profileUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="srm-modal-assignee"
+                  >
+                    <img src={a.avatarUrl} alt={a.login} className="srm-modal-avatar" width={28} height={28} />
+                    <span className="srm-modal-assignee-name">{a.login}</span>
+                  </a>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {extraFields.length > 0 && (
+            <dl className="srm-modal-fields">
+              {extraFields.map(([k, v]) => (
+                v != null && (
+                  <div key={k} className="srm-modal-field">
+                    <dt>{k}</dt>
+                    <dd>{String(v)}</dd>
+                  </div>
+                )
+              ))}
+            </dl>
+          )}
+        </div>
+
+        <footer className="srm-modal-footer">
+          {item.url && (
+            <a
+              className="srm-modal-github"
+              href={item.url}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              View on GitHub →
+            </a>
+          )}
+          <button
+            ref={closeBtnRef}
+            type="button"
+            className="srm-modal-close"
+            aria-label="Close"
+            onClick={onClose}
           >
-            View on GitHub →
-          </a>
-        )}
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M6 6l12 12M6 18L18 6" />
+            </svg>
+          </button>
+        </footer>
       </div>
     </div>
   );

--- a/src/styles/scratchytd.css
+++ b/src/styles/scratchytd.css
@@ -1686,7 +1686,6 @@
 .srm-modal-github {
   display: inline-flex;
   align-items: center;
-  margin-top: 22px;
   padding: 8px 16px;
   border-radius: 50px;
   background: #F4845F;
@@ -1699,6 +1698,14 @@
 .srm-modal-github:hover {
   background: #D9654A;
   transform: translateY(-1px);
+}
+
+.srm-modal-footer {
+  margin-top: 22px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
 }
 
 /* Roadmap responsive */
@@ -1758,13 +1765,46 @@
 
   .srm-modal-backdrop {
     padding: 0;
-    align-items: flex-end;
+    align-items: stretch;
   }
   .srm-modal {
     max-width: none;
-    max-height: 92vh;
-    border-radius: 20px 20px 0 0;
-    padding: 22px 18px 22px;
+    width: 100%;
+    height: 100vh;
+    height: 100dvh;
+    max-height: 100vh;
+    max-height: 100dvh;
+    border-radius: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+  .srm-modal-scroll {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    padding: 20px 18px 16px;
+  }
+  .srm-modal-footer {
+    flex-shrink: 0;
+    margin-top: 0;
+    padding: 12px 16px calc(12px + env(safe-area-inset-bottom));
+    border-top: 1px solid #F0E3D1;
+    background: #FFF8F0;
+    justify-content: space-between;
+    gap: 10px;
+  }
+  .srm-modal-close {
+    position: static;
+    top: auto;
+    right: auto;
+    flex-shrink: 0;
+    margin-left: auto;
+  }
+  .srm-modal-close:hover {
+    transform: none;
   }
   .srm-modal-title { font-size: 1.15rem; }
   .srm-modal-body { font-size: 0.88rem; }


### PR DESCRIPTION
## Summary
- Restructure `BoardCardModal` into a scrollable content area plus a pinned `srm-modal-footer` that holds the close button and the View on GitHub link.
- At viewports `<= 600px`, the modal now stretches edge-to-edge (anchored to the top, using `100dvh` with a `100vh` fallback) and the footer is glued to the bottom, so the close X and the GitHub CTA stay reachable with one thumb — even on cards with short bodies. Respects `env(safe-area-inset-bottom)` for notched devices.
- Desktop behavior is unchanged: the close X stays absolutely pinned to the top-right of the modal.

## Test plan
- [x] `npm test` — 78/79 (the one failure is the pre-existing `renders hero icons from data` landing test, unrelated)
  - New tests under `Modal footer layout`:
    - close button lives inside `.srm-modal-footer`
    - View on GitHub link lives inside `.srm-modal-footer`
    - footer comes after `.srm-modal-body` in DOM order
- [ ] Manual desktop (>= 768px): open a card on the roadmap, confirm close X is in the top-right and the GitHub CTA renders inline below the body content.
- [ ] Manual mobile (Chrome DevTools iPhone 14 Pro / 375 px): confirm the modal fills the viewport from the top, body scrolls internally (page underneath is locked), footer stays pinned at the bottom with GitHub left + close right, both buttons remain visible even for cards with very short bodies.
- [ ] Confirm ESC, backdrop click, and the close button all dismiss and restore focus to the originating card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)